### PR TITLE
Fix distribution detection so that Ubuntu does not identify as Debian

### DIFF
--- a/config/zfs-build.m4
+++ b/config/zfs-build.m4
@@ -232,6 +232,8 @@ AC_DEFUN([ZFS_AC_DEFAULT_PACKAGE], [
 		VENDOR=fedora ;
 	elif test -f /etc/gentoo-release ; then
 		VENDOR=gentoo ;
+	elif test -f /etc/lsb-release ; then
+		VENDOR=ubuntu ;
 	elif test -f /etc/debian_version ; then
 		VENDOR=debian ;
 	elif test -f /etc/SuSE-release ; then
@@ -240,8 +242,6 @@ AC_DEFUN([ZFS_AC_DEFAULT_PACKAGE], [
 		VENDOR=slackware ;
 	elif test -f /etc/arch-release ; then
 		VENDOR=arch ;
-	elif test -f /etc/lsb-release ; then
-		VENDOR=ubuntu ;
 	elif test -f /etc/lunar.release ; then
 		VENDOR=lunar ;
 	else

--- a/configure
+++ b/configure
@@ -11680,6 +11680,8 @@ $as_echo_n "checking linux distribution... " >&6; }
 		VENDOR=fedora ;
 	elif test -f /etc/gentoo-release ; then
 		VENDOR=gentoo ;
+	elif test -f /etc/lsb-release ; then
+		VENDOR=ubuntu ;
 	elif test -f /etc/debian_version ; then
 		VENDOR=debian ;
 	elif test -f /etc/SuSE-release ; then
@@ -11688,8 +11690,6 @@ $as_echo_n "checking linux distribution... " >&6; }
 		VENDOR=slackware ;
 	elif test -f /etc/arch-release ; then
 		VENDOR=arch ;
-	elif test -f /etc/lsb-release ; then
-		VENDOR=ubuntu ;
 	elif test -f /etc/lunar.release ; then
 		VENDOR=lunar ;
 	else


### PR DESCRIPTION
This is meant to bring things in synchronization with the build system changes made in the corresponding zfsonlinux/spl pull request:

https://github.com/zfsonlinux/spl/pull/86
