### PR TITLE
Illumos #1346: zfs incremental receive may leave behind temporary clones

### DIFF
--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright 2011 Martin Matuska
  */
 
 #include <sys/types.h>
@@ -1921,8 +1922,10 @@ top:
 		uint64_t cookie = 0;
 		int len = sizeof (zc->zc_name) - (p - zc->zc_name);
 
-		while (dmu_dir_list_next(os, len, p, NULL, &cookie) == 0)
-			(void) dmu_objset_prefetch(p, NULL);
+		while (dmu_dir_list_next(os, len, p, NULL, &cookie) == 0) {
+			if (!dataset_name_hidden(zc->zc_name))
+				(void) dmu_objset_prefetch(zc->zc_name, NULL);
+		}
 	}
 
 	do {


### PR DESCRIPTION
1356 zfs dataset prefetch code not working
Reviewed by: Matthew Ahrens matt@delphix.com
Reviewed by: Dan McDonald danmcd@nexenta.com
Approved by: Gordon Ross gwr@nexenta.com
